### PR TITLE
Add Publish command. 

### DIFF
--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -79,8 +79,12 @@ var publishCmd = &cobra.Command{
 			owner := paths[l-2]
 
 			// Send HTTP request
-			_, err := http.Get(registry + "?owner=" + owner + "&repo=" + repo)
+			client := &http.Client{}
+			request, err := http.NewRequest("PUT", registry+"?owner="+owner+"&repo="+repo, nil)
 			utils.Check(err)
+			_, err = client.Do(request)
+			utils.Check(err)
+
 		} else {
 			log.Print("Fatal error: missing repository URL in manifest file.")
 		}

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -1,0 +1,94 @@
+// Copyright © 2017 NAME HERE <EMAIL ADDRESS>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+
+	"bufio"
+	"github.com/openwhisk/openwhisk-wskdeploy/parsers"
+	"github.com/openwhisk/openwhisk-wskdeploy/utils"
+	"github.com/spf13/cobra"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"strings"
+)
+
+// publishCmd represents the publish command
+var publishCmd = &cobra.Command{
+	Use:   "publish",
+	Short: "Publish a package to a registry",
+	Long:  `Publish a package to the registry set in ~/.wskprops`,
+	Run: func(cmd *cobra.Command, args []string) {
+		// Get registry location
+
+		userHome := utils.GetHomeDirectory()
+		propPath := path.Join(userHome, ".wskprops")
+
+		configs, err := utils.ReadProps(propPath)
+		utils.Check(err)
+
+		registry, ok := configs["REGISTRY"]
+		if !ok {
+			reader := bufio.NewReader(os.Stdin)
+			fmt.Print("Registry URL not found in ~./wskprops. Must be set before publishing.\n")
+			for {
+				registry = utils.Ask(reader, "Registry URL", "")
+
+				_, err := url.Parse(registry)
+				if err == nil {
+					// TODO: send request to registry to check it exists.
+					break
+				}
+				log.Print("Malformed repository URL. Try again")
+
+			}
+			configs["REGISTRY"] = registry
+			utils.WriteProps(propPath, configs)
+		}
+
+		// Get repo URL
+		maniyaml := parsers.ReadOrCreateManifest()
+
+		if len(maniyaml.Package.Repositories) > 0 {
+			repoURL := maniyaml.Package.Repositories[0].Url
+
+			paths := strings.Split(repoURL, "/")
+			l := len(paths)
+			if l < 2 {
+				log.Print("Fatal error: malformed repository URL in manifest file :" + repoURL)
+				return
+			}
+
+			repo := paths[l-1]
+			owner := paths[l-2]
+
+			// Send HTTP request
+			_, err := http.Get(registry + "?owner=" + owner + "&repo=" + repo)
+			utils.Check(err)
+		} else {
+			log.Print("Fatal error: missing repository URL in manifest file.")
+		}
+
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(publishCmd)
+
+}

--- a/parsers/yamlparser.go
+++ b/parsers/yamlparser.go
@@ -93,12 +93,19 @@ type Rule struct {
 	Name string
 }
 
+type Repository struct {
+	Url         string `yaml:"url"`
+	Description string `yaml:"description,omitempty"`
+	Credential  string `yaml:"credential,omitempty"`
+}
+
 type Package struct {
 	//mapping to wsk.SentPackageNoPublish.Name
 	Packagename string `yaml:"name"` //used in manifest.yaml
 	//mapping to wsk.SentPackageNoPublish.Version
-	Version           string                `yaml:"version"`            //used in manifest.yaml
-	License           string                `yaml:"license"`            //used in manifest.yaml
+	Version           string                `yaml:"version"` //used in manifest.yaml
+	License           string                `yaml:"license"` //used in manifest.yaml
+	Repositories      []Repository          `yaml:"repositories,omitempty"`
 	Dependencies      map[string]Dependency `yaml: dependencies`        // used in manifest.yaml
 	Function          string                `yaml:"function"`           //used in deployment.yaml
 	PackageCredential string                `yaml:"package_credential"` //used in deployment.yaml

--- a/utils/fileoperations.go
+++ b/utils/fileoperations.go
@@ -126,6 +126,30 @@ func ReadProps(path string) (map[string]string, error) {
 
 }
 
+func WriteProps(path string, props map[string]string) error {
+	file, err := os.Create(path)
+	if err != nil {
+		fmt.Printf("Warning: Unable to create whisk properties file '%s' (file create error: %s)\n", path, err)
+		return err
+	}
+	defer file.Close()
+
+	for k, v := range props {
+		_, err := file.WriteString(k)
+		Check(err)
+
+		_, err = file.WriteString("=")
+		Check(err)
+
+		_, err = file.WriteString(v)
+		Check(err)
+
+		_, err = file.WriteString("\n")
+		Check(err)
+	}
+	return nil
+}
+
 // Load configuration will load properties from a file
 func LoadConfiguration(propPath string) ([]string, error) {
 	props, err := ReadProps(propPath)


### PR DESCRIPTION
For now it only registers the package to a configurable OpenWhisk Hub. The registry URL is stored in ~/.wskprops. 