### PR TITLE
Add the support of github release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,24 @@
+# A Travis CI configuration file.
+
 language: go
+
 go:
-- 1.7
+  - 1.7
+
 install:
-- go get -u github.com/golang/lint/golint
+  - go get -u github.com/golang/lint/golint
+
 script:
-- make lint
-- make build
+  - make lint
+  - make build
+
 before_deploy:
   - export build_file_name=wskdeploy
   - go get github.com/inconshreveable/mousetrap
   - ./tools/travis/build_tag_releases.sh $build_file_name
   - export RELEASE_PKG_FILE=$(ls $build_file_name-*.zip)
   - echo "Deploying $RELEASE_PKG_FILE to GitHub releases."
+
 deploy:
   provider: releases
   api_key:

--- a/tools/travis/build_tag_releases.sh
+++ b/tools/travis/build_tag_releases.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+declare -a os_list=("linux" "darwin" "windows")
+arc=amd64
+build_file_name=${1:-"$wskdeploy"}
+
+for os in "${os_list[@]}"
+do
+    GOOS=$os GOARCH=$arc go build -o $build_file_name-$os-$arc
+    zip -r "$build_file_name-$TRAVIS_TAG-$os-$arc.zip" $build_file_name-$os-$arc
+done


### PR DESCRIPTION
This patch adds the travis support to package the prebuilt binary of
wskdeploy into a zip file and release automatically on github.

Closes-Issue: #180