### PR TITLE
Rename the binaries into wskdeploy within zip files

### DIFF
--- a/tools/travis/build_tag_releases.sh
+++ b/tools/travis/build_tag_releases.sh
@@ -2,10 +2,16 @@
 
 declare -a os_list=("linux" "darwin" "windows")
 arc=amd64
-build_file_name=${1:-"$wskdeploy"}
+file_name=${1:-"wskdeploy"}
 
 for os in "${os_list[@]}"
 do
-    GOOS=$os GOARCH=$arc go build -o $build_file_name-$os-$arc
-    zip -r "$build_file_name-$TRAVIS_TAG-$os-$arc.zip" $build_file_name-$os-$arc
+    build_file_name=$file_name
+    if [ "$os" == "windows" ]; then
+        build_file_name="$build_file_name.exe"
+    fi
+    cd $TRAVIS_BUILD_DIR
+    GOOS=$os GOARCH=$arc go build -o build/$os/$build_file_name
+    cd build/$os
+    zip -r "$TRAVIS_BUILD_DIR/$build_file_name-$TRAVIS_TAG-$os-$arc.zip" $build_file_name
 done


### PR DESCRIPTION
Under windows, the binary name is wskdeploy.exe.
Under Linux and Mac, the binary name is wskdeploy.