### PR TITLE
wskdeploy can now run as an openwhisk action.

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,7 +31,11 @@ import (
 
 	"regexp"
 
+	"encoding/json"
+	"errors"
 	"github.com/openwhisk/openwhisk-client-go/whisk"
+	"github.com/openwhisk/openwhisk-client-go/wski18n"
+	"strings"
 )
 
 var RootCmd = &cobra.Command{
@@ -69,7 +73,7 @@ wskdeploy without any commands or flags deploys openwhisk package in the current
 
 		}
 
-		if utils.FileExists(manifestPath) {
+		if utils.MayExists(manifestPath) {
 
 			var deployer = deployers.NewServiceDeployer()
 			deployer.ProjectPath = projectPath
@@ -83,9 +87,11 @@ wskdeploy without any commands or flags deploys openwhisk package in the current
 
 			deployer.IsInteractive = useInteractive
 
-			userHome := utils.GetHomeDirectory()
-			propPath := path.Join(userHome, ".wskprops")
-
+			propPath := ""
+			if !utils.Flags.WithinOpenWhisk {
+				userHome := utils.GetHomeDirectory()
+				propPath = path.Join(userHome, ".wskprops")
+			}
 			whiskClient, clientConfig := deployers.NewWhiskClient(propPath, deploymentPath, deployer.IsInteractive)
 			deployer.Client = whiskClient
 			deployer.ClientConfig = clientConfig
@@ -97,7 +103,11 @@ wskdeploy without any commands or flags deploys openwhisk package in the current
 			utils.Check(err)
 
 		} else {
-			log.Println("missing manifest.yaml file")
+			if utils.Flags.WithinOpenWhisk {
+				utils.PrintOpenWhiskError(wski18n.T("missing manifest.yaml file"))
+			} else {
+				log.Println("missing manifest.yaml file")
+			}
 		}
 
 	},
@@ -106,13 +116,51 @@ wskdeploy without any commands or flags deploys openwhisk package in the current
 // Execute adds all child commands to the root command sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
+	if utils.Flags.WithinOpenWhisk {
+		err := substCmdArgs()
+		if err != nil {
+			utils.PrintOpenWhiskError(err.Error())
+			return
+		}
+	}
+
 	if err := RootCmd.Execute(); err != nil {
-		fmt.Println(err)
-		os.Exit(-1)
+		log.Println(err)
+		if utils.Flags.WithinOpenWhisk {
+			utils.PrintOpenWhiskError(err.Error())
+		} else {
+			os.Exit(-1)
+		}
+	} else {
+		if utils.Flags.WithinOpenWhisk {
+			fmt.Print(`{"deploy":"success"}`) // maybe return report of what has been deployed.
+		}
 	}
 }
 
+func substCmdArgs() error {
+	// Extract arguments from input JSON string
+
+	// { "cmd": ".." } // space-separated arguments
+
+	arg := os.Args[1]
+
+	// unmarshal the string to a JSON object
+	var obj map[string]interface{}
+	json.Unmarshal([]byte(arg), &obj)
+
+	if v, ok := obj["cmd"].(string); ok {
+		regex, _ := regexp.Compile("[ ]+")
+		os.Args = regex.Split("wskdeploy "+strings.TrimSpace(v), -1)
+	} else {
+		return errors.New(wski18n.T("Missing cmd key"))
+	}
+	return nil
+}
+
 func init() {
+	utils.Flags.WithinOpenWhisk = len(os.Getenv("__OW_API_HOST")) > 0
+
 	cobra.OnInitialize(initConfig)
 
 	// Here you will define your flags and configuration settings.
@@ -126,9 +174,12 @@ func init() {
 	RootCmd.Flags().StringVarP(&projectPath, "pathpath", "p", ".", "path to serverless project")
 	RootCmd.Flags().StringVarP(&manifestPath, "manifest", "m", "", "path to manifest file")
 	RootCmd.Flags().StringVarP(&deploymentPath, "deployment", "d", "", "path to deployment file")
-	RootCmd.PersistentFlags().BoolVarP(&useInteractive, "allow-interactive", "i", true, "allow interactive prompts")
+	RootCmd.PersistentFlags().BoolVarP(&useInteractive, "allow-interactive", "i", !utils.Flags.WithinOpenWhisk, "allow interactive prompts")
 	RootCmd.PersistentFlags().BoolVarP(&useDefaults, "allow-defaults", "a", false, "allow defaults")
 	RootCmd.PersistentFlags().BoolVarP(&Verbose, "verbose", "v", false, "verbose output")
+	RootCmd.PersistentFlags().StringVarP(&utils.Flags.ApiHost, "apihost", "", "", wski18n.T("whisk API HOST"))
+	RootCmd.PersistentFlags().StringVarP(&utils.Flags.Auth, "auth", "u", "", wski18n.T("authorization `KEY`"))
+	RootCmd.PersistentFlags().StringVar(&utils.Flags.ApiVersion, "apiversion", "", wski18n.T("whisk API `VERSION`"))
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/shared.go
+++ b/cmd/shared.go
@@ -29,6 +29,7 @@ var CliVersion string
 var CliBuild string
 
 // used to configure service deployer for various commands
+// TODO: should move this into utils.Flags
 var Verbose bool
 var projectPath string
 var deploymentPath string

--- a/cmd/undeploy.go
+++ b/cmd/undeploy.go
@@ -106,8 +106,4 @@ func init() {
 	undeployCmd.Flags().StringVarP(&projectPath, "pathpath", "p", ".", "path to serverless project")
 	undeployCmd.Flags().StringVarP(&manifestPath, "manifest", "m", "", "path to manifest file")
 	undeployCmd.Flags().StringVarP(&deploymentPath, "deployment", "d", "", "path to deployment file")
-	undeployCmd.PersistentFlags().BoolVarP(&useDefaults, "allow-defaults", "f", false, "allow defaults")
-	undeployCmd.PersistentFlags().BoolVarP(&useInteractive, "allow-interactive", "i", true, "allow interactive prompts")
-	undeployCmd.PersistentFlags().BoolVarP(&Verbose, "verbose", "v", false, "verbose output")
-
 }

--- a/deployers/whiskclient.go
+++ b/deployers/whiskclient.go
@@ -37,6 +37,9 @@ func NewWhiskClient(proppath string, deploymentPath string, isInteractive bool) 
 	utils.Check(err)
 
 	credential := configs[2]
+	if len(utils.Flags.Auth) > 0 {
+		credential = utils.Flags.Auth
+	}
 	namespace := configs[0]
 
 	if namespace == "" {
@@ -45,6 +48,10 @@ func NewWhiskClient(proppath string, deploymentPath string, isInteractive bool) 
 	//we need to get Apihost from property file which currently not defined in sample deployment file.
 
 	u := configs[1]
+	if len(utils.Flags.ApiHost) > 0 {
+		u = utils.Flags.ApiHost
+	}
+
 	var baseURL *url.URL
 
 	if u == "" && isInteractive == true {
@@ -62,7 +69,7 @@ func NewWhiskClient(proppath string, deploymentPath string, isInteractive bool) 
 	} else if u == "" {
 		// handle some error
 	} else {
-		baseURL, err = utils.GetURLBase(configs[1])
+		baseURL, err = utils.GetURLBase(u)
 		utils.Check(err)
 	}
 

--- a/parsers/manifest_parser.go
+++ b/parsers/manifest_parser.go
@@ -74,8 +74,10 @@ func (dm *YAMLParser) Marshal(manifest *ManifestYAML) (output []byte, err error)
 func (dm *YAMLParser) ParseManifest(mani string) *ManifestYAML {
 	mm := NewYAMLParser()
 	maniyaml := ManifestYAML{}
-	content, err := new(utils.ContentReader).LocalReader.ReadLocal(mani)
+
+	content, err := utils.Read(mani)
 	utils.Check(err)
+
 	err = mm.Unmarshal(content, &maniyaml)
 	utils.Check(err)
 	maniyaml.Filepath = mani
@@ -151,7 +153,7 @@ func (dm *YAMLParser) ComposeActions(mani *ManifestYAML, manipath string) ([]uti
 		if action.Location != "" {
 			filePath := strings.TrimRight(manipath, splitmanipath[len(splitmanipath)-1]) + action.Location
 			action.Location = filePath
-			dat, err := new(utils.ContentReader).LocalReader.ReadLocal(filePath)
+			dat, err := utils.Read(filePath)
 			utils.Check(err)
 			code := string(dat)
 			wskaction.Exec.Code = &code

--- a/utils/contentreader.go
+++ b/utils/contentreader.go
@@ -20,6 +20,7 @@ package utils
 import (
 	"io/ioutil"
 	"net/http"
+	"strings"
 )
 
 // agnostic util reader to fetch content from web or local path or potentially other places.
@@ -47,4 +48,12 @@ func (localReader *LocalReader) ReadLocal(path string) (content []byte, err erro
 	cont, err := ioutil.ReadFile(path)
 	Check(err)
 	return cont, nil
+}
+
+func Read(url string) (content []byte, err error) {
+	if strings.HasPrefix(url, "http") {
+		return new(ContentReader).URLReader.ReadUrl(url)
+	} else {
+		return new(ContentReader).LocalReader.ReadLocal(url)
+	}
 }

--- a/utils/errorhandlers.go
+++ b/utils/errorhandlers.go
@@ -19,6 +19,7 @@ package utils
 
 import (
 	"errors"
+	"fmt"
 	"log"
 	"os"
 )
@@ -44,8 +45,15 @@ func Check(e error) {
 		log.Printf("%v", e)
 		erro := errors.New("Error happened during execution, please type 'wskdeploy -h' for help messages.")
 		log.Printf("%v", erro)
-		os.Exit(1)
+		if Flags.WithinOpenWhisk {
+			PrintOpenWhiskError(e.Error())
+		} else {
+			os.Exit(1)
+		}
 
 	}
+}
 
+func PrintOpenWhiskError(err string) {
+	fmt.Print(`{"error":"` + err + `"}`)
 }

--- a/utils/fileoperations.go
+++ b/utils/fileoperations.go
@@ -27,7 +27,16 @@ import (
 	"strings"
 
 	"github.com/openwhisk/openwhisk-client-go/whisk"
+	"log"
 )
+
+func MayExists(file string) bool {
+	if strings.HasPrefix(file, "http") {
+		return true // to avoid multiple fetches
+	} else {
+		return FileExists(file)
+	}
+}
 
 func FileExists(file string) bool {
 	_, err := os.Stat(file)
@@ -118,7 +127,7 @@ func ReadProps(path string) (map[string]string, error) {
 	file, err := os.Open(path)
 	if err != nil {
 		// If file does not exist, just return props
-		fmt.Printf("Warning: Unable to read whisk properties file '%s' (file open error: %s)\n", path, err)
+		log.Printf("Warning: Unable to read whisk properties file '%s' (file open error: %s)\n", path, err)
 		return props, nil
 	}
 	defer file.Close()

--- a/utils/flags.go
+++ b/utils/flags.go
@@ -1,0 +1,8 @@
+package utils
+
+var Flags struct {
+	WithinOpenWhisk bool   // is this running within an OpenWhisk action?
+	ApiHost         string // OpenWhisk API host
+	Auth            string // OpenWhisk API key
+	ApiVersion      string // OpenWhisk version
+}

--- a/wski18n/resources/en_US.all.json
+++ b/wski18n/resources/en_US.all.json
@@ -2,5 +2,26 @@
   {
     "id": "Hello",
     "translation": "An API host must be provided."
+  },
+  {
+    "id": "Missing cmd key",
+    "translation": "Missing 'cmd' input key"
+  },
+  {
+    "id": "missing manifest.yaml file",
+    "translation": "Missing manifest.yaml file"
+  },
+  {
+  "id": "authorization `KEY`",
+  "translation": "authorization `KEY`"
+  },
+  {
+    "id": "whisk API `HOST`",
+    "translation": "whisk API `HOST`"
+  },
+  {
+    "id": "whisk API `VERSION`",
+    "translation": "whisk API `VERSION`"
   }
+
 ]


### PR DESCRIPTION
This PR enables wskdeploy to run as an OpenWhisk action inside a go docker container. (#189)

- New flags have been added:

      --apihost HOST         whisk API HOST
      --apiversion VERSION   whisk API VERSION
      -u, --auth KEY             authorization KEY

- Modified flags:
      -m now accept URL pointing to the manifest.

- Read action content either from local file system or remote http location.
- Fix duplicated persistent flag declarations.

