### PR TITLE
Add the missing double quote to the field baseUrl for deployment application

### DIFF
--- a/parsers/yamlparser.go
+++ b/parsers/yamlparser.go
@@ -143,7 +143,7 @@ type Application struct {
 	Name       string             `yaml:"name"`      //used in deployment.yaml
 	Namespace  string             `yaml:"namespace"` //used in deployment.yaml
 	Credential string             `yaml:"credential"`
-	BaseUrl    string             `yaml: baseUrl`
+	BaseUrl    string             `yaml:"baseUrl"`
 	Version    string             `yaml:"version"`
 	Packages   map[string]Package `yaml:"packages"` //used in deployment.yaml
 	Package    Package            `yaml:"package"`

--- a/tests/dat/deploy1.yaml
+++ b/tests/dat/deploy1.yaml
@@ -1,4 +1,6 @@
 application:
   name: wskdeploy-samples
   namespace: /wskdeploy/samples/
+  credential: user-credential
+  baseUrl: https://172.17.0.1/api
 

--- a/tests/src/parser/yamlparser_test.go
+++ b/tests/src/parser/yamlparser_test.go
@@ -139,6 +139,8 @@ func TestParseDeploymentYAML_Application(t *testing.T) {
 	//get and verify application name
 	assert.Equal(t, "wskdeploy-samples", deployment.Application.Name, "Get application name failed.")
 	assert.Equal(t, "/wskdeploy/samples/", deployment.Application.Namespace, "Get application namespace failed.")
+	assert.Equal(t, "user-credential", deployment.Application.Credential, "Get application credential failed.")
+	assert.Equal(t, "https://172.17.0.1/api", deployment.Application.BaseUrl, "Get application base url failed.")
 }
 
 func TestParseDeploymentYAML_Package(t *testing.T) {


### PR DESCRIPTION
Since there is a missing double quote for the field baseUrl, it is unable
to be parsed. This PR adds the quote to field baseUrl making it able to
be parsed.

Besides, this PR adds the test coverage to parse baseUrl and credential.
Closes-Bug: #205