### PR TITLE
Add openwhisk installation in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,30 @@
 # A Travis CI configuration file.
 
+sudo: required
+
 language: go
 
 go:
   - 1.7
 
+services:
+  - docker
+
 install:
+  - export DEPLOY_BUILD_READY=false
   - go get -u github.com/golang/lint/golint
 
 script:
   - make lint
   - make build
+  - export OPENWHISK_HOME="$(dirname "$TRAVIS_BUILD_DIR")/openwhisk"
+  - ./tools/travis/install_openwhisk.sh
+
+after_success:
+  - DEPLOY_BUILD_READY=true
+
+after_script:
+  - make clean
 
 before_deploy:
   - export build_file_name=wskdeploy
@@ -29,3 +43,4 @@ deploy:
   on:
     repo: openwhisk/openwhisk-wskdeploy
     tags: true
+    condition: "$DEPLOY_BUILD_READY = true"

--- a/tools/travis/install_openwhisk.sh
+++ b/tools/travis/install_openwhisk.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+HOMEDIR="$(dirname "$TRAVIS_BUILD_DIR")"
+cd $HOMEDIR
+
+sudo gpasswd -a travis docker
+sudo -E bash -c 'echo '\''DOCKER_OPTS="-H tcp://0.0.0.0:4243 -H unix:///var/run/docker.sock --api-enable-cors --storage-driver=aufs"'\'' > /etc/default/docker'
+
+# Docker
+sudo apt-get -y update -qq
+sudo apt-get -o Dpkg::Options::="--force-confold" --force-yes -y install docker-engine=1.12.0-0~trusty
+sudo service docker restart
+echo "Docker Version:"
+docker version
+echo "Docker Info:"
+docker info
+
+# Ansible
+pip install --user ansible==2.1.2.0
+
+# OpenWhisk stuff
+git clone --depth 3 https://github.com/openwhisk/openwhisk.git
+
+# Build script for Travis-CI.
+WHISKDIR="$HOMEDIR/openwhisk"
+
+ANSIBLE_CMD="ansible-playbook -i environments/local"
+
+cd $WHISKDIR/ansible
+$ANSIBLE_CMD setup.yml
+$ANSIBLE_CMD prereq.yml
+$ANSIBLE_CMD couchdb.yml
+$ANSIBLE_CMD initdb.yml
+
+cd $WHISKDIR
+./gradlew distDocker
+
+cd $WHISKDIR/ansible
+$ANSIBLE_CMD wipe.yml
+$ANSIBLE_CMD openwhisk.yml


### PR DESCRIPTION
This PR lays up a foundation to run integration tests against openwhisk
in Travis CI to guarentee the code quality.

An environment varible DEPLOY_BUILD_READY is added and will be set true
when the installation and test cases pass without error. In addition,
travic deploy section is available when DEPLOY_BUILD_READY is set to true.

After the installation, add "make clean" to remove the binaries.