### PR TITLE
Remodel the CMD package by separating the implementations

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/openwhisk/openwhisk-wskdeploy/cmdImp"
 	"github.com/openwhisk/openwhisk-wskdeploy/parsers"
 	"github.com/openwhisk/openwhisk-wskdeploy/utils"
 	"github.com/spf13/cobra"
@@ -48,7 +49,7 @@ var initCmd = &cobra.Command{
 
 func askName(reader *bufio.Reader, def string) string {
 	if len(def) == 0 {
-		abspath, err := filepath.Abs(projectPath)
+		abspath, err := filepath.Abs(cmdImp.ProjectPath)
 		utils.Check(err)
 		def = filepath.Base(abspath)
 	}

--- a/cmd/report.go
+++ b/cmd/report.go
@@ -29,6 +29,7 @@ import (
 	"github.com/openwhisk/openwhisk-wskdeploy/utils"
 	"github.com/openwhisk/openwhisk-wskdeploy/wski18n"
 	"github.com/spf13/cobra"
+	"github.com/openwhisk/openwhisk-wskdeploy/cmdImp"
 )
 
 var wskpropsPath string
@@ -46,12 +47,12 @@ located under current user home.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// TODO: Work your own magic here
 		if wskpropsPath != "" {
-			client, _ = deployers.NewWhiskClient(wskpropsPath, deploymentPath, false)
+			client, _ = deployers.NewWhiskClient(wskpropsPath, cmdImp.DeploymentPath, false)
 		}
 		userHome := utils.GetHomeDirectory()
 		//default to ~/.wskprops
 		propPath := path.Join(userHome, ".wskprops")
-		client, _ = deployers.NewWhiskClient(propPath, deploymentPath, false)
+		client, _ = deployers.NewWhiskClient(propPath, cmdImp.DeploymentPath, false)
 		printDeploymentInfo(client)
 	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,10 +21,8 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"path"
-	"path/filepath"
 
-	"github.com/openwhisk/openwhisk-wskdeploy/deployers"
+	"github.com/openwhisk/openwhisk-wskdeploy/cmdImp"
 	"github.com/openwhisk/openwhisk-wskdeploy/utils"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -33,7 +31,6 @@ import (
 
 	"encoding/json"
 	"errors"
-	"github.com/openwhisk/openwhisk-client-go/whisk"
 	"github.com/openwhisk/openwhisk-client-go/wski18n"
 	"strings"
 )
@@ -48,69 +45,16 @@ wskdeploy without any commands or flags deploys openwhisk package in the current
       `,
 	// Uncomment the following line if your bare application
 	// has an action associated with it:
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: RootCmdImp,
+}
 
-		whisk.SetVerbose(Verbose)
+func RootCmdImp(cmd *cobra.Command, args []string) {
+	// Set all the parameters passed via the command to the struct of wskdeploy command.
+	deployParams := cmdImp.DeployParams{cmdImp.Verbose, cmdImp.ProjectPath, cmdImp.ManifestPath,
+		cmdImp.DeploymentPath, cmdImp.UseDefaults, cmdImp.UseInteractive}
+	// Call the implementation of wskdeploy command.
+	cmdImp.Deploy(deployParams)
 
-		projectPath, err := filepath.Abs(projectPath)
-		utils.Check(err)
-
-		if manifestPath == "" {
-			if ok, _ := regexp.Match(ManifestFileNameYml, []byte(manifestPath)); ok {
-				manifestPath = path.Join(projectPath, ManifestFileNameYml)
-			} else {
-				manifestPath = path.Join(projectPath, ManifestFileNameYaml)
-			}
-
-		}
-
-		if deploymentPath == "" {
-			if ok, _ := regexp.Match(DeploymentFileNameYml, []byte(manifestPath)); ok {
-				deploymentPath = path.Join(projectPath, DeploymentFileNameYml)
-			} else {
-				deploymentPath = path.Join(projectPath, DeploymentFileNameYaml)
-			}
-
-		}
-
-		if utils.MayExists(manifestPath) {
-
-			var deployer = deployers.NewServiceDeployer()
-			deployer.ProjectPath = projectPath
-			deployer.ManifestPath = manifestPath
-			deployer.DeploymentPath = deploymentPath
-			// perform some quick check here.
-			go func() {
-				deployer.Check()
-			}()
-			deployer.IsDefault = useDefaults
-
-			deployer.IsInteractive = useInteractive
-
-			propPath := ""
-			if !utils.Flags.WithinOpenWhisk {
-				userHome := utils.GetHomeDirectory()
-				propPath = path.Join(userHome, ".wskprops")
-			}
-			whiskClient, clientConfig := deployers.NewWhiskClient(propPath, deploymentPath, deployer.IsInteractive)
-			deployer.Client = whiskClient
-			deployer.ClientConfig = clientConfig
-
-			err := deployer.ConstructDeploymentPlan()
-			utils.Check(err)
-
-			err = deployer.Deploy()
-			utils.Check(err)
-
-		} else {
-			if utils.Flags.WithinOpenWhisk {
-				utils.PrintOpenWhiskError(wski18n.T("missing manifest.yaml file"))
-			} else {
-				log.Println("missing manifest.yaml file")
-			}
-		}
-
-	},
 }
 
 // Execute adds all child commands to the root command sets flags appropriately.
@@ -167,16 +111,16 @@ func init() {
 	// Cobra supports Persistent Flags, which, if defined here,
 	// will be global for your application.
 
-	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.wskdeploy.yaml)")
+	RootCmd.PersistentFlags().StringVar(&cmdImp.CfgFile, "config", "", "config file (default is $HOME/.wskdeploy.yaml)")
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
 	RootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
-	RootCmd.Flags().StringVarP(&projectPath, "pathpath", "p", ".", "path to serverless project")
-	RootCmd.Flags().StringVarP(&manifestPath, "manifest", "m", "", "path to manifest file")
-	RootCmd.Flags().StringVarP(&deploymentPath, "deployment", "d", "", "path to deployment file")
-	RootCmd.PersistentFlags().BoolVarP(&useInteractive, "allow-interactive", "i", !utils.Flags.WithinOpenWhisk, "allow interactive prompts")
-	RootCmd.PersistentFlags().BoolVarP(&useDefaults, "allow-defaults", "a", false, "allow defaults")
-	RootCmd.PersistentFlags().BoolVarP(&Verbose, "verbose", "v", false, "verbose output")
+	RootCmd.Flags().StringVarP(&cmdImp.ProjectPath, "pathpath", "p", ".", "path to serverless project")
+	RootCmd.Flags().StringVarP(&cmdImp.ManifestPath, "manifest", "m", "", "path to manifest file")
+	RootCmd.Flags().StringVarP(&cmdImp.DeploymentPath, "deployment", "d", "", "path to deployment file")
+	RootCmd.PersistentFlags().BoolVarP(&cmdImp.UseInteractive, "allow-interactive", "i", !utils.Flags.WithinOpenWhisk, "allow interactive prompts")
+	RootCmd.PersistentFlags().BoolVarP(&cmdImp.UseDefaults, "allow-defaults", "a", false, "allow defaults")
+	RootCmd.PersistentFlags().BoolVarP(&cmdImp.Verbose, "verbose", "v", false, "verbose output")
 	RootCmd.PersistentFlags().StringVarP(&utils.Flags.ApiHost, "apihost", "", "", wski18n.T("whisk API HOST"))
 	RootCmd.PersistentFlags().StringVarP(&utils.Flags.Auth, "auth", "u", "", wski18n.T("authorization `KEY`"))
 	RootCmd.PersistentFlags().StringVar(&utils.Flags.ApiVersion, "apiversion", "", wski18n.T("whisk API `VERSION`"))
@@ -184,9 +128,9 @@ func init() {
 
 // initConfig reads in config file and ENV variables if set.
 func initConfig() {
-	if cfgFile != "" {
+	if cmdImp.CfgFile != "" {
 		// enable ability to specify config file via flag
-		viper.SetConfigFile(cfgFile)
+		viper.SetConfigFile(cmdImp.CfgFile)
 	}
 
 	viper.SetConfigName(".wskdeploy") // name of config file (without extension)

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -20,6 +20,7 @@ package cmd
 import (
 	"fmt"
 	"github.com/spf13/cobra"
+	"github.com/openwhisk/openwhisk-wskdeploy/cmdImp"
 )
 
 func init() {
@@ -31,6 +32,6 @@ var versionCmd = &cobra.Command{
 	Short: "Print the version number of openwhisk-wskdeploy",
 	Long:  `Print the version number of openwhisk-wskdeploy`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("openwhisk-wskdeploy version is %s--%s\n", CliBuild, CliVersion)
+		fmt.Printf("openwhisk-wskdeploy version is %s--%s\n", cmdImp.CliBuild, cmdImp.CliVersion)
 	},
 }

--- a/cmdImp/rootImp.go
+++ b/cmdImp/rootImp.go
@@ -1,0 +1,97 @@
+package cmdImp
+
+import (
+	"github.com/openwhisk/openwhisk-wskdeploy/utils"
+	"path"
+	"github.com/openwhisk/openwhisk-wskdeploy/deployers"
+	"log"
+	"github.com/openwhisk/openwhisk-client-go/whisk"
+	"github.com/openwhisk/openwhisk-client-go/wski18n"
+	"path/filepath"
+	"regexp"
+	"errors"
+)
+
+type DeployParams struct {
+	Verbose bool
+	ProjectPath string
+	ManifestPath string
+	DeploymentPath string
+	UseDefaults bool
+	UseInteractive bool
+}
+
+func Deploy(params DeployParams) error {
+
+	whisk.SetVerbose(params.Verbose)
+
+	projectPath, err := filepath.Abs(params.ProjectPath)
+	utils.Check(err)
+
+	if params.ManifestPath == "" {
+		if ok, _ := regexp.Match(ManifestFileNameYml, []byte(params.ManifestPath)); ok {
+			params.ManifestPath = path.Join(projectPath, ManifestFileNameYml)
+		} else {
+			params.ManifestPath = path.Join(projectPath, ManifestFileNameYaml)
+		}
+
+	}
+
+	if params.DeploymentPath == "" {
+		if ok, _ := regexp.Match(DeploymentFileNameYml, []byte(params.ManifestPath)); ok {
+			params.DeploymentPath = path.Join(projectPath, DeploymentFileNameYml)
+		} else {
+			params.DeploymentPath = path.Join(projectPath, DeploymentFileNameYaml)
+		}
+
+	}
+
+	if utils.MayExists(params.ManifestPath) {
+
+		var deployer = deployers.NewServiceDeployer()
+		deployer.ProjectPath = projectPath
+		deployer.ManifestPath = params.ManifestPath
+		deployer.DeploymentPath = params.DeploymentPath
+		// perform some quick check here.
+		go func() {
+			deployer.Check()
+		}()
+		deployer.IsDefault = params.UseDefaults
+
+		deployer.IsInteractive = params.UseInteractive
+
+		propPath := ""
+		if !utils.Flags.WithinOpenWhisk {
+			userHome := utils.GetHomeDirectory()
+			propPath = path.Join(userHome, ".wskprops")
+		}
+		whiskClient, clientConfig := deployers.NewWhiskClient(propPath, params.DeploymentPath, deployer.IsInteractive)
+		deployer.Client = whiskClient
+		deployer.ClientConfig = clientConfig
+
+		err := deployer.ConstructDeploymentPlan()
+
+		if err != nil {
+			utils.Check(err)
+			return err
+		}
+
+		err = deployer.Deploy()
+		if err != nil {
+			utils.Check(err)
+			return err
+		} else {
+			return nil
+		}
+
+	} else {
+		if utils.Flags.WithinOpenWhisk {
+			utils.PrintOpenWhiskError(wski18n.T("missing manifest.yaml file"))
+			return errors.New("missing manifest.yaml file")
+		} else {
+			log.Println("missing manifest.yaml file")
+			return errors.New("missing manifest.yaml file")
+		}
+	}
+
+}

--- a/cmdImp/shared.go
+++ b/cmdImp/shared.go
@@ -16,7 +16,7 @@
  */
 
 // shared.go
-package cmd
+package cmdImp
 
 // name of manifest and deployment files
 const ManifestFileNameYaml = "manifest.yaml"
@@ -24,15 +24,15 @@ const ManifestFileNameYml = "manifest.yml"
 const DeploymentFileNameYaml = "deployment.yaml"
 const DeploymentFileNameYml = "deployment.yml"
 
-var cfgFile string
+var CfgFile string
 var CliVersion string
 var CliBuild string
 
 // used to configure service deployer for various commands
 // TODO: should move this into utils.Flags
 var Verbose bool
-var projectPath string
-var deploymentPath string
-var manifestPath string
-var useDefaults bool
-var useInteractive bool
+var ProjectPath string
+var DeploymentPath string
+var ManifestPath string
+var UseDefaults bool
+var UseInteractive bool

--- a/cmdImp/undeployImp.go
+++ b/cmdImp/undeployImp.go
@@ -1,0 +1,65 @@
+package cmdImp
+
+import (
+	"github.com/openwhisk/openwhisk-wskdeploy/utils"
+	"path"
+	"github.com/openwhisk/openwhisk-wskdeploy/deployers"
+	"log"
+	"github.com/openwhisk/openwhisk-client-go/whisk"
+	"regexp"
+	"errors"
+)
+
+func Undeploy(params DeployParams) error {
+	// TODO: Work your own magic here
+	whisk.SetVerbose(params.Verbose)
+
+	if params.ManifestPath == "" {
+		if ok, _ := regexp.Match(ManifestFileNameYml, []byte(params.ManifestPath)); ok {
+			params.ManifestPath = path.Join(params.ProjectPath, ManifestFileNameYml)
+		} else {
+			params.ManifestPath = path.Join(params.ProjectPath, ManifestFileNameYaml)
+		}
+
+	}
+
+	if params.DeploymentPath == "" {
+		if ok, _ := regexp.Match(DeploymentFileNameYml, []byte(params.ManifestPath)); ok {
+			params.DeploymentPath = path.Join(params.ProjectPath, DeploymentFileNameYml)
+		} else {
+			params.DeploymentPath = path.Join(params.ProjectPath, DeploymentFileNameYaml)
+		}
+
+	}
+
+	if utils.FileExists(params.ManifestPath) {
+
+		var deployer = deployers.NewServiceDeployer()
+		deployer.ProjectPath = params.ProjectPath
+		deployer.ManifestPath = params.ManifestPath
+		deployer.DeploymentPath = params.DeploymentPath
+
+		deployer.IsInteractive = params.UseInteractive
+		deployer.IsDefault = params.UseDefaults
+
+		userHome := utils.GetHomeDirectory()
+		propPath := path.Join(userHome, ".wskprops")
+
+		whiskClient, clientConfig := deployers.NewWhiskClient(propPath, params.DeploymentPath, deployer.IsInteractive)
+		deployer.Client = whiskClient
+		deployer.ClientConfig = clientConfig
+
+		verifiedPlan, err := deployer.ConstructUnDeploymentPlan()
+		err = deployer.UnDeploy(verifiedPlan)
+		if err != nil {
+			utils.Check(err)
+			return err
+		} else {
+			return nil
+		}
+
+	} else {
+		log.Println("missing manifest.yaml file")
+		return errors.New("missing manifest.yaml file")
+	}
+}

--- a/deployers/servicedeployer.go
+++ b/deployers/servicedeployer.go
@@ -260,7 +260,10 @@ func (deployer *ServiceDeployer) DeployActions() error {
 
 	for _, pack := range deployer.Deployment.Packages {
 		for _, action := range pack.Actions {
-			deployer.createAction(pack.Package.Name, action.Action)
+			err := deployer.createAction(pack.Package.Name, action.Action)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -386,7 +389,7 @@ func (deployer *ServiceDeployer) createRule(rule *whisk.Rule) {
 }
 
 // Utility function to call go-whisk framework to make action
-func (deployer *ServiceDeployer) createAction(pkgname string, action *whisk.Action) {
+func (deployer *ServiceDeployer) createAction(pkgname string, action *whisk.Action) error {
 	// call ActionService Thru Client
 	if deployer.DeployActionInPackage {
 		// the action will be created under package with pattern 'packagename/actionname'
@@ -397,8 +400,10 @@ func (deployer *ServiceDeployer) createAction(pkgname string, action *whisk.Acti
 	if err != nil {
 		wskErr := err.(*whisk.WskError)
 		log.Printf("Got error creating action with error message: %v and error code: %v.\n", wskErr.Error(), wskErr.ExitCode)
+		return err
 	}
 	log.Println("Done!")
+	return nil
 }
 
 func (deployer *ServiceDeployer) UnDeploy(verifiedPlan *DeploymentApplication) error {
@@ -492,7 +497,10 @@ func (deployer *ServiceDeployer) UnDeployActions(deployment *DeploymentApplicati
 
 	for _, pack := range deployment.Packages {
 		for _, action := range pack.Actions {
-			deployer.deleteAction(pack.Package.Name, action.Action)
+			err := deployer.deleteAction(pack.Package.Name, action.Action)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -600,7 +608,7 @@ func (deployer *ServiceDeployer) deleteRule(rule *whisk.Rule) {
 }
 
 // Utility function to call go-whisk framework to make action
-func (deployer *ServiceDeployer) deleteAction(pkgname string, action *whisk.Action) {
+func (deployer *ServiceDeployer) deleteAction(pkgname string, action *whisk.Action) error {
 	// call ActionService Thru Client
 	if deployer.DeployActionInPackage {
 		// the action will be deleted under package with pattern 'packagename/actionname'
@@ -612,8 +620,10 @@ func (deployer *ServiceDeployer) deleteAction(pkgname string, action *whisk.Acti
 	if err != nil {
 		wskErr := err.(*whisk.WskError)
 		log.Printf("Got error deleting action with error message: %v and error code: %v.\n", wskErr.Error(), wskErr.ExitCode)
+		return err
 	}
 	fmt.Println("Done!")
+	return nil
 }
 
 // from whisk go client

--- a/main.go
+++ b/main.go
@@ -17,7 +17,10 @@
 
 package main
 
-import "github.com/openwhisk/openwhisk-wskdeploy/cmd"
+import (
+	"github.com/openwhisk/openwhisk-wskdeploy/cmd"
+	"github.com/openwhisk/openwhisk-wskdeploy/cmdImp"
+)
 
 func main() {
 	cmd.Execute()
@@ -31,6 +34,6 @@ var (
 )
 
 func init() {
-	cmd.CliVersion = Version
-	cmd.CliBuild = Build
+	cmdImp.CliVersion = Version
+	cmdImp.CliBuild = Build
 }


### PR DESCRIPTION
This PR separates the CMD interface and the implementation for easy test
of wskdeploy and undeploy commands.

In addition, the error message should be returned when action fails to
be created.