### PR TITLE
Add local packages as the resource to build binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,42 +10,18 @@ ENV GOPATH=/
 RUN echo "Installing the godep tool"
 RUN go get github.com/tools/godep
 
-
-RUN echo "Installing the go-bindata tool"
-RUN go get github.com/jteeuwen/go-bindata/...
-
-
-
-ADD . /src/github.com/
-
-RUN go get github.com/openwhisk/openwhisk-client-go/whisk
-
-RUN cd /src/github.com/openwhisk/openwhisk-client-go/whisk && git fetch && git checkout i18n
-
-RUN git clone http://github.com/openwhisk/openwhisk-wskdeploy /src/github.com/openwhisk/openwhisk-wskdeploy
-
-RUN cd /src/github.com/openwhisk/openwhisk-wskdeploy && git checkout master
+ADD . /src/github.com/openwhisk/openwhisk-wskdeploy
 
 # Load all of the dependencies from the previously generated/saved godep generated godeps.json file
 RUN echo "Restoring Go dependencies"
-RUN cd /src/github.com && /bin/godep restore -v
-
-# Collect all translated strings into single .go module
-RUN echo "Generating i18n Go module"
-RUN cd /src/github.com && /bin/go-bindata -pkg wski18n -o wski18n/i18n_resources.go wski18n/resources
-
-# Generate a Go package dependency list
-# NOTE: Currently, the 'go list' command will not work against the current Go CLI non-standard file structure
-#RUN cd /src/github.com/go-whisk-cli && go list -f '{{join .Deps "\n"}}' > ../../../wsk.deps.out
-RUN cd /src/github.com/ && echo "Dependencies list requires restructuring the GO CLI packages" > wskdeploy.deps.out
-
+RUN cd /src/github.com/openwhisk/openwhisk-wskdeploy && /bin/godep restore -v
 
 # All of the Go CLI binaries will be placed under a build folder
-RUN mkdir /src/github.com/build
+RUN mkdir /src/github.com/openwhisk/openwhisk-wskdeploy/build
 
 ARG WSKDEPLOY_OS
 ARG WSKDEPLOY_ARCH
 
 # Build the Go wsk CLI binaries and compress resultant binaries
-RUN chmod +x /src/github.com/build.sh
-RUN cd /src/github.com/ && ./build.sh
+RUN chmod +x /src/github.com/openwhisk/openwhisk-wskdeploy/build.sh
+RUN cd /src/github.com/openwhisk/openwhisk-wskdeploy/ && ./build.sh

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ task distBinary(dependsOn: [removeBinary, distDocker]) {
 
         // Copy all Go binaries from Docker into openwhisk/bin folder
         run(dockerBinary + ["cp", dockerContainerName +
-                ":/src/github.com/build/.", "${projectDir}/bin"])
+                ":/src/github.com/openwhisk/openwhisk-wskdeploy/build/.", "${projectDir}/bin"])
 
         run(dockerBinary + ["rm", "-f", dockerContainerName])
     }

--- a/build.sh
+++ b/build.sh
@@ -29,7 +29,7 @@ build_wskdeploy () {
 
   export GOARCH=$arch
 
-  cd /src/github.com
+  cd /src/github.com/openwhisk/openwhisk-wskdeploy
   go build -ldflags "-X main.Version=`date -u '+%Y-%m-%dT%H:%M:%S'`" -v -o build/$os/$arch/$bin main.go;
 };
 


### PR DESCRIPTION
This patch makes sure that dockerfile gets rid of pulling code
from github.com. Intead the code is copied from the local
packages, so that docker will build the binaries based on the
local changes.

Closes-Bug: #228