### PR TITLE
Add GitHub based dependencies key to deploy and undeploy

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -22,7 +22,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/openwhisk/openwhisk-wskdeploy/cmdImp"
+	"github.com/openwhisk/openwhisk-wskdeploy/deployers"
 	"github.com/openwhisk/openwhisk-wskdeploy/parsers"
 	"github.com/openwhisk/openwhisk-wskdeploy/utils"
 	"github.com/spf13/cobra"
@@ -49,7 +49,7 @@ var initCmd = &cobra.Command{
 
 func askName(reader *bufio.Reader, def string) string {
 	if len(def) == 0 {
-		abspath, err := filepath.Abs(cmdImp.ProjectPath)
+		abspath, err := filepath.Abs(deployers.ProjectPath)
 		utils.Check(err)
 		def = filepath.Base(abspath)
 	}

--- a/cmd/report.go
+++ b/cmd/report.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/openwhisk/openwhisk-client-go/whisk"
-	"github.com/openwhisk/openwhisk-wskdeploy/cmdImp"
 	"github.com/openwhisk/openwhisk-wskdeploy/deployers"
 	"github.com/openwhisk/openwhisk-wskdeploy/utils"
 	"github.com/openwhisk/openwhisk-wskdeploy/wski18n"
@@ -47,12 +46,12 @@ located under current user home.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// TODO: Work your own magic here
 		if wskpropsPath != "" {
-			client, _ = deployers.NewWhiskClient(wskpropsPath, cmdImp.DeploymentPath, false)
+			client, _ = deployers.NewWhiskClient(wskpropsPath, deployers.DeploymentPath, false)
 		}
 		userHome := utils.GetHomeDirectory()
 		//default to ~/.wskprops
 		propPath := path.Join(userHome, ".wskprops")
-		client, _ = deployers.NewWhiskClient(propPath, cmdImp.DeploymentPath, false)
+		client, _ = deployers.NewWhiskClient(propPath, deployers.DeploymentPath, false)
 		printDeploymentInfo(client)
 	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,6 +23,7 @@ import (
 	"os"
 
 	"github.com/openwhisk/openwhisk-wskdeploy/cmdImp"
+	"github.com/openwhisk/openwhisk-wskdeploy/deployers"
 	"github.com/openwhisk/openwhisk-wskdeploy/utils"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -31,8 +32,9 @@ import (
 
 	"encoding/json"
 	"errors"
-	"github.com/openwhisk/openwhisk-client-go/wski18n"
 	"strings"
+
+	"github.com/openwhisk/openwhisk-client-go/wski18n"
 )
 
 var RootCmd = &cobra.Command{
@@ -50,8 +52,8 @@ wskdeploy without any commands or flags deploys openwhisk package in the current
 
 func RootCmdImp(cmd *cobra.Command, args []string) {
 	// Set all the parameters passed via the command to the struct of wskdeploy command.
-	deployParams := cmdImp.DeployParams{cmdImp.Verbose, cmdImp.ProjectPath, cmdImp.ManifestPath,
-		cmdImp.DeploymentPath, cmdImp.UseDefaults, cmdImp.UseInteractive}
+	deployParams := cmdImp.DeployParams{deployers.Verbose, deployers.ProjectPath, deployers.ManifestPath,
+		deployers.DeploymentPath, deployers.UseDefaults, deployers.UseInteractive}
 	// Call the implementation of wskdeploy command.
 	cmdImp.Deploy(deployParams)
 
@@ -111,16 +113,16 @@ func init() {
 	// Cobra supports Persistent Flags, which, if defined here,
 	// will be global for your application.
 
-	RootCmd.PersistentFlags().StringVar(&cmdImp.CfgFile, "config", "", "config file (default is $HOME/.wskdeploy.yaml)")
+	RootCmd.PersistentFlags().StringVar(&deployers.CfgFile, "config", "", "config file (default is $HOME/.wskdeploy.yaml)")
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
 	RootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
-	RootCmd.Flags().StringVarP(&cmdImp.ProjectPath, "pathpath", "p", ".", "path to serverless project")
-	RootCmd.Flags().StringVarP(&cmdImp.ManifestPath, "manifest", "m", "", "path to manifest file")
-	RootCmd.Flags().StringVarP(&cmdImp.DeploymentPath, "deployment", "d", "", "path to deployment file")
-	RootCmd.PersistentFlags().BoolVarP(&cmdImp.UseInteractive, "allow-interactive", "i", !utils.Flags.WithinOpenWhisk, "allow interactive prompts")
-	RootCmd.PersistentFlags().BoolVarP(&cmdImp.UseDefaults, "allow-defaults", "a", false, "allow defaults")
-	RootCmd.PersistentFlags().BoolVarP(&cmdImp.Verbose, "verbose", "v", false, "verbose output")
+	RootCmd.Flags().StringVarP(&deployers.ProjectPath, "pathpath", "p", ".", "path to serverless project")
+	RootCmd.Flags().StringVarP(&deployers.ManifestPath, "manifest", "m", "", "path to manifest file")
+	RootCmd.Flags().StringVarP(&deployers.DeploymentPath, "deployment", "d", "", "path to deployment file")
+	RootCmd.PersistentFlags().BoolVarP(&deployers.UseInteractive, "allow-interactive", "i", !utils.Flags.WithinOpenWhisk, "allow interactive prompts")
+	RootCmd.PersistentFlags().BoolVarP(&deployers.UseDefaults, "allow-defaults", "a", false, "allow defaults")
+	RootCmd.PersistentFlags().BoolVarP(&deployers.Verbose, "verbose", "v", false, "verbose output")
 	RootCmd.PersistentFlags().StringVarP(&utils.Flags.ApiHost, "apihost", "", "", wski18n.T("whisk API HOST"))
 	RootCmd.PersistentFlags().StringVarP(&utils.Flags.Auth, "auth", "u", "", wski18n.T("authorization `KEY`"))
 	RootCmd.PersistentFlags().StringVar(&utils.Flags.ApiVersion, "apiversion", "", wski18n.T("whisk API `VERSION`"))
@@ -128,9 +130,9 @@ func init() {
 
 // initConfig reads in config file and ENV variables if set.
 func initConfig() {
-	if cmdImp.CfgFile != "" {
+	if deployers.CfgFile != "" {
 		// enable ability to specify config file via flag
-		viper.SetConfigFile(cmdImp.CfgFile)
+		viper.SetConfigFile(deployers.CfgFile)
 	}
 
 	viper.SetConfigName(".wskdeploy") // name of config file (without extension)

--- a/cmd/undeploy.go
+++ b/cmd/undeploy.go
@@ -19,6 +19,7 @@ package cmd
 
 import (
 	"github.com/openwhisk/openwhisk-wskdeploy/cmdImp"
+	"github.com/openwhisk/openwhisk-wskdeploy/deployers"
 	"github.com/spf13/cobra"
 )
 
@@ -32,8 +33,8 @@ var undeployCmd = &cobra.Command{
 
 func UndeployCmdImp(cmd *cobra.Command, args []string) {
 	// Set all the parameters passed via the command to the struct of undeploy command.
-	undeployParams := cmdImp.DeployParams{cmdImp.Verbose, cmdImp.ProjectPath, cmdImp.ManifestPath,
-		cmdImp.DeploymentPath, cmdImp.UseDefaults, cmdImp.UseInteractive}
+	undeployParams := cmdImp.DeployParams{deployers.Verbose, deployers.ProjectPath, deployers.ManifestPath,
+		deployers.DeploymentPath, deployers.UseDefaults, deployers.UseInteractive}
 	// Call the implementation of wskdeploy command.
 	cmdImp.Undeploy(undeployParams)
 }
@@ -46,12 +47,12 @@ func init() {
 	// Cobra supports Persistent Flags which will work for this command
 	// and all subcommands, e.g.:
 	// undeployCmd.PersistentFlags().String("foo", "", "A help for foo")
-	undeployCmd.PersistentFlags().StringVar(&cmdImp.CfgFile, "config", "", "config file (default is $HOME/.wskdeploy.yaml)")
+	undeployCmd.PersistentFlags().StringVar(&deployers.CfgFile, "config", "", "config file (default is $HOME/.wskdeploy.yaml)")
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
 	// undeployCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")=
 	undeployCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
-	undeployCmd.Flags().StringVarP(&cmdImp.ProjectPath, "pathpath", "p", ".", "path to serverless project")
-	undeployCmd.Flags().StringVarP(&cmdImp.ManifestPath, "manifest", "m", "", "path to manifest file")
-	undeployCmd.Flags().StringVarP(&cmdImp.DeploymentPath, "deployment", "d", "", "path to deployment file")
+	undeployCmd.Flags().StringVarP(&deployers.ProjectPath, "pathpath", "p", ".", "path to serverless project")
+	undeployCmd.Flags().StringVarP(&deployers.ManifestPath, "manifest", "m", "", "path to manifest file")
+	undeployCmd.Flags().StringVarP(&deployers.DeploymentPath, "deployment", "d", "", "path to deployment file")
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -19,7 +19,8 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/openwhisk/openwhisk-wskdeploy/cmdImp"
+
+	"github.com/openwhisk/openwhisk-wskdeploy/deployers"
 	"github.com/spf13/cobra"
 )
 
@@ -32,6 +33,6 @@ var versionCmd = &cobra.Command{
 	Short: "Print the version number of openwhisk-wskdeploy",
 	Long:  `Print the version number of openwhisk-wskdeploy`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("openwhisk-wskdeploy version is %s--%s\n", cmdImp.CliBuild, cmdImp.CliVersion)
+		fmt.Printf("openwhisk-wskdeploy version is %s--%s\n", deployers.CliBuild, deployers.CliVersion)
 	},
 }

--- a/deployers/manifestreader.go
+++ b/deployers/manifestreader.go
@@ -58,6 +58,8 @@ func (reader *ManifestReader) InitRootPackage(manifestParser *parsers.YAMLParser
 // Wrapper parser to handle yaml dir
 func (deployer *ManifestReader) HandleYaml(sdeployer *ServiceDeployer, manifestParser *parsers.YAMLParser, manifest *parsers.ManifestYAML) error {
 
+	deps, err := manifestParser.ComposeDependencies(manifest, deployer.serviceDeployer.ProjectPath)
+
 	actions, aubindings, err := manifestParser.ComposeActions(manifest, deployer.serviceDeployer.ManifestPath)
 	utils.Check(err)
 
@@ -68,6 +70,9 @@ func (deployer *ManifestReader) HandleYaml(sdeployer *ServiceDeployer, manifestP
 	utils.Check(err)
 
 	rules, err := manifestParser.ComposeRules(manifest)
+	utils.Check(err)
+
+	err = deployer.SetDependencies(deps)
 	utils.Check(err)
 
 	err = deployer.SetActions(actions)
@@ -85,6 +90,29 @@ func (deployer *ManifestReader) HandleYaml(sdeployer *ServiceDeployer, manifestP
 	//only set api if aubindings
 	if len(aubindings) != 0 {
 		err = deployer.SetApis(sdeployer, aubindings)
+	}
+
+	return nil
+}
+
+func (reader *ManifestReader) SetDependencies(deps map[string]utils.DependencyRecord) error {
+	for depName, dep := range deps {
+		if !dep.IsBinding {
+			if _, exists := reader.serviceDeployer.DependencyMaster[depName]; !exists {
+				// clone dependency
+				gitReader := utils.NewGitReader(depName, dep)
+				err := gitReader.CloneDependency()
+				utils.Check(err)
+			} else {
+				// TODO: we should do a check to make sure this dependency is compatible with an already installed one.
+				// If not, we should throw dependency mismatch error.
+			}
+		}
+
+		// store in two places (one local to package to preserve relationship, one in master record to check for conflics
+		reader.serviceDeployer.Deployment.Packages[dep.Packagename].Dependencies[depName] = dep
+		reader.serviceDeployer.DependencyMaster[depName] = dep
+
 	}
 
 	return nil

--- a/deployers/shared.go
+++ b/deployers/shared.go
@@ -16,7 +16,7 @@
  */
 
 // shared.go
-package cmdImp
+package deployers
 
 // name of manifest and deployment files
 const ManifestFileNameYaml = "manifest.yaml"

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ package main
 
 import (
 	"github.com/openwhisk/openwhisk-wskdeploy/cmd"
-	"github.com/openwhisk/openwhisk-wskdeploy/cmdImp"
+	"github.com/openwhisk/openwhisk-wskdeploy/deployers"
 )
 
 func main() {
@@ -34,6 +34,6 @@ var (
 )
 
 func init() {
-	cmdImp.CliVersion = Version
-	cmdImp.CliBuild = Build
+	deployers.CliVersion = Version
+	deployers.CliBuild = Build
 }

--- a/parsers/manifest_parser.go
+++ b/parsers/manifest_parser.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"encoding/json"
+
 	"github.com/openwhisk/openwhisk-client-go/whisk"
 	"github.com/openwhisk/openwhisk-wskdeploy/utils"
 	"gopkg.in/yaml.v2"
@@ -85,6 +86,52 @@ func (dm *YAMLParser) ParseManifest(mani string) *ManifestYAML {
 	return &maniyaml
 }
 
+func (dm *YAMLParser) ComposeDependencies(mani *ManifestYAML, projectPath string) (map[string]utils.DependencyRecord, error) {
+
+	depMap := make(map[string]utils.DependencyRecord)
+	for key, dependency := range mani.Package.Dependencies {
+		version := dependency.Version
+		if version == "" {
+			version = "master"
+		}
+
+		// one of these is should be empty
+		url := dependency.Url
+		source := dependency.Source
+
+		isBinding := false
+		if source != "" {
+			isBinding = true
+		}
+
+		keyValArrParams := make(whisk.KeyValueArr, 0)
+		for name, param := range dependency.Inputs {
+			var keyVal whisk.KeyValue
+			keyVal.Key = name
+
+			keyVal.Value = ResolveParameter(&param)
+
+			if keyVal.Value != nil {
+				keyValArrParams = append(keyValArrParams, keyVal)
+			}
+		}
+
+		keyValArrAnot := make(whisk.KeyValueArr, 0)
+		for name, value := range dependency.Annotations {
+			var keyVal whisk.KeyValue
+			keyVal.Key = name
+			keyVal.Value = utils.GetEnvVar(value)
+
+			keyValArrAnot = append(keyValArrAnot, keyVal)
+		}
+
+		packDir := path.Join(projectPath, "Packages")
+		depMap[key] = utils.DependencyRecord{packDir, mani.Package.Packagename, url, source, version, keyValArrParams, keyValArrAnot, isBinding}
+	}
+
+	return depMap, nil
+}
+
 // Is we consider multi pacakge in one yaml?
 func (dm *YAMLParser) ComposePackage(mani *ManifestYAML) (*whisk.Package, error) {
 	//mani := dm.ParseManifest(manipath)
@@ -126,7 +173,7 @@ func (dm *YAMLParser) ComposeSequences(namespace string, mani *ManifestYAML) ([]
 
 			act := strings.TrimSpace(a)
 
-			if !strings.HasPrefix(act, mani.Package.Packagename+"/") {
+			if !strings.ContainsRune(act, '/') && !strings.HasPrefix(act, mani.Package.Packagename+"/") {
 				act = path.Join(mani.Package.Packagename, act)
 			}
 			components = append(components, path.Join("/"+namespace, act))
@@ -294,6 +341,15 @@ func (dm *YAMLParser) ComposeRules(manifest *ManifestYAML) ([]*whisk.Rule, error
 	pkg := manifest.Package
 	for _, rule := range pkg.GetRuleList() {
 		wskrule := rule.ComposeWskRule()
+
+		act := strings.TrimSpace(wskrule.Action.(string))
+
+		if !strings.ContainsRune(act, '/') && !strings.HasPrefix(act, pkg.Packagename+"/") {
+			act = path.Join(pkg.Packagename, act)
+		}
+
+		wskrule.Action = act
+
 		r1 = append(r1, wskrule)
 	}
 

--- a/parsers/yamlparser.go
+++ b/parsers/yamlparser.go
@@ -71,9 +71,11 @@ type Sequence struct {
 }
 
 type Dependency struct {
-	Name    string
-	Url     string
-	Version string
+	Url         string                 `yaml: "url"`
+	Source      string                 `yaml: "source"`
+	Version     string                 `yaml: "version, omitempty"`
+	Inputs      map[string]Parameter   `yaml:"inputs"`
+	Annotations map[string]interface{} `yaml:"annotations"`
 }
 
 type Parameter struct {
@@ -190,6 +192,7 @@ func (rule *Rule) ComposeWskRule() *whisk.Rule {
 	pub := false
 	wskrule.Publish = &pub
 	wskrule.Trigger = rule.Trigger
+
 	wskrule.Action = rule.Action
 	return wskrule
 }

--- a/tests/usecases/deptest/manifest.yml
+++ b/tests/usecases/deptest/manifest.yml
@@ -1,0 +1,23 @@
+package:
+  name: opentest
+  dependencies:
+    hellowhisk:
+      url: https://github.com/paulcastro/hellowhisk
+    myCloudant:
+      source: /whisk.system/cloudant
+      inputs:
+        dbname: myGreatDB
+      annotations:
+        myAnnotation: Here it is
+  sequences:
+    mySequence:
+      actions: hellowhisk/greeting, hellowhisk/httpGet
+  triggers:
+    myTrigger:
+  rules:
+    myRule:
+      trigger: myTrigger
+      action: hellowhisk/httpGet
+    myCloudantRule:
+      trigger: myTrigger
+      action: myCloudant/create-database

--- a/tests/usecases/openstack/manifest.yaml
+++ b/tests/usecases/openstack/manifest.yaml
@@ -2,10 +2,6 @@ package:
   name: JiraBackupSolution
   version: 0.0.1
   license: Apache-2.0
-  dependencies:
-    SwiftyJson:
-      url: https://swiftyjson.com
-      version: 0.4.0
   actions:
     getApiToken:
       location: actions/getApiToken.js

--- a/utils/gitreader.go
+++ b/utils/gitreader.go
@@ -1,0 +1,87 @@
+// gitreader.go
+package utils
+
+import (
+	"archive/zip"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+type GitReader struct {
+	Name        string
+	Url         string
+	Version     string
+	ProjectPath string
+}
+
+func NewGitReader(projectName string, record DependencyRecord) *GitReader {
+	var gitReader GitReader
+
+	gitReader.Name = projectName
+	gitReader.Url = record.Url
+	gitReader.Version = record.Version
+
+	gitReader.ProjectPath = record.ProjectPath
+
+	return &gitReader
+
+}
+
+func (reader *GitReader) CloneDependency() error {
+	zipFileName := reader.Name + "." + reader.Version + ".zip"
+	zipFilePath := reader.Url + "/zipball" + "/" + reader.Version
+
+	os.MkdirAll(reader.ProjectPath, os.ModePerm)
+	output, err := os.Create(path.Join(reader.ProjectPath, zipFileName))
+	Check(err)
+	defer output.Close()
+
+	response, err := http.Get(zipFilePath)
+	Check(err)
+	defer response.Body.Close()
+
+	_, err = io.Copy(output, response.Body)
+	Check(err)
+
+	zipReader, err := zip.OpenReader(path.Join(reader.ProjectPath, zipFileName))
+	Check(err)
+
+	u, err := url.Parse(reader.Url)
+	team, project := path.Split(u.Path)
+
+	team = strings.TrimPrefix(team, "/")
+	team = strings.TrimSuffix(team, "/")
+
+	for _, file := range zipReader.File {
+		path := filepath.Join(reader.ProjectPath, file.Name)
+
+		if file.FileInfo().IsDir() {
+			os.MkdirAll(path, file.Mode())
+			continue
+		}
+
+		fileReader, err := file.Open()
+		Check(err)
+		defer fileReader.Close()
+
+		targetFile, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, file.Mode())
+		Check(err)
+		defer targetFile.Close()
+
+		if _, err := io.Copy(targetFile, fileReader); err != nil {
+			return err
+		}
+	}
+
+	rootDir := filepath.Join(reader.ProjectPath, zipReader.File[0].Name)
+	depPath := filepath.Join(reader.ProjectPath, project+"-"+reader.Version)
+	os.Rename(rootDir, depPath)
+	os.Remove(filepath.Join(reader.ProjectPath, zipFileName))
+
+	return nil
+}

--- a/utils/misc.go
+++ b/utils/misc.go
@@ -24,9 +24,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/hokaccha/go-prettyjson"
-	"github.com/openwhisk/openwhisk-client-go/whisk"
-	"github.com/openwhisk/openwhisk-wskdeploy/wski18n"
 	"io"
 	"net/url"
 	"os"
@@ -34,6 +31,10 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+
+	"github.com/hokaccha/go-prettyjson"
+	"github.com/openwhisk/openwhisk-client-go/whisk"
+	"github.com/openwhisk/openwhisk-wskdeploy/wski18n"
 )
 
 // ActionRecord is a container to keep track of
@@ -43,6 +44,17 @@ type ActionRecord struct {
 	Action      *whisk.Action
 	Packagename string
 	Filepath    string
+}
+
+type DependencyRecord struct {
+	ProjectPath string
+	Packagename string
+	Url         string
+	Source      string
+	Version     string
+	Parameters  whisk.KeyValueArr
+	Annotations whisk.KeyValueArr
+	IsBinding   bool
 }
 
 type TriggerRecord struct {


### PR DESCRIPTION
This is a first cut at adding dependencies to a manifest.yml file.  This adds a `dependencies` key where the dependency is a GitHub repo.

```
package:
  name: opentest
  dependencies:
      hellowhisk:
          url: https://github.com/paulcastro/hellowhisk
          version: 1.0.1
      myCloudant:
           source: /whisk.system/cloudant
           inputs:
                  dbname: MyGreatDB
  sequences:
    mySequence:
      actions: hellowhisk/greeting, hellowhisk/httpGet
  triggers:
    myTrigger:
  rules:
    myRule:
      trigger: myTrigger
```
This manifest references a GitHub project aliased as "hellowhisk", version 1.0.1 at the given URL.  If `version` is not specified, it will pull from `master`.

Dependencies that specify a `source` are interpreted as bindings, and we do a package bind.  `url` specifies a GitHub dependency and is treated as an independent deployment.  For example, the root package `opentest` refers to entities in the `hellowhisk` package using the package name format.  The following happens on deploy

1. wskdeploy downloads and unpacks a zip file of the gihub repo in `$ProjectPath/Packages/<dependencyname>`
2. Deploys dependencies first
3. Deploys root package

This PR does not include dependency graph management so use at your own risk.

There is a use case in tests/usescases/deptest that illustrates a project that has no local source code, just a manifest that combines the entities in a dependency.