### PR TITLE
Add dependencies and bindings

### DIFF
--- a/cmdImp/rootImp.go
+++ b/cmdImp/rootImp.go
@@ -10,6 +10,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"os"
 )
 
 type DeployParams struct {
@@ -29,21 +30,31 @@ func Deploy(params DeployParams) error {
 	utils.Check(err)
 
 	if params.ManifestPath == "" {
-		if ok, _ := regexp.Match(ManifestFileNameYml, []byte(params.ManifestPath)); ok {
-			params.ManifestPath = path.Join(projectPath, ManifestFileNameYml)
+		if ok, _ := regexp.Match(deployers.ManifestFileNameYml, []byte(params.ManifestPath)); ok {
+			params.ManifestPath = path.Join(projectPath, deployers.ManifestFileNameYml)
 		} else {
-			params.ManifestPath = path.Join(projectPath, ManifestFileNameYaml)
+			params.ManifestPath = path.Join(projectPath, deployers.ManifestFileNameYaml)
 		}
-
+	} else {
+		if _, err := os.Stat(path.Join(projectPath, "manifest.yaml")); err == nil {
+			params.ManifestPath = path.Join(projectPath, deployers.ManifestFileNameYaml)
+		} else if _, err := os.Stat(path.Join(projectPath, "manifest.yml")); err == nil {
+			params.ManifestPath = path.Join(projectPath, deployers.ManifestFileNameYml)
+		}
 	}
 
 	if params.DeploymentPath == "" {
-		if ok, _ := regexp.Match(DeploymentFileNameYml, []byte(params.ManifestPath)); ok {
-			params.DeploymentPath = path.Join(projectPath, DeploymentFileNameYml)
+		if ok, _ := regexp.Match(deployers.DeploymentFileNameYml, []byte(params.ManifestPath)); ok {
+			params.DeploymentPath = path.Join(projectPath, deployers.DeploymentFileNameYml)
 		} else {
-			params.DeploymentPath = path.Join(projectPath, DeploymentFileNameYaml)
+			params.DeploymentPath = path.Join(projectPath, deployers.DeploymentFileNameYaml)
 		}
-
+	} else {
+		if _, err := os.Stat(path.Join(projectPath, "deployment.yaml")); err == nil {
+			params.DeploymentPath = path.Join(projectPath, deployers.DeploymentFileNameYaml)
+		} else if _, err := os.Stat(path.Join(projectPath, "deployment.yml")); err == nil {
+			params.DeploymentPath = path.Join(projectPath, deployers.DeploymentFileNameYml)
+		}
 	}
 
 	if utils.MayExists(params.ManifestPath) {
@@ -59,6 +70,9 @@ func Deploy(params DeployParams) error {
 		deployer.IsDefault = params.UseDefaults
 
 		deployer.IsInteractive = params.UseInteractive
+
+		// master record of any dependency that has been downloaded
+		deployer.DependencyMaster = make(map[string]utils.DependencyRecord)
 
 		propPath := ""
 		if !utils.Flags.WithinOpenWhisk {

--- a/cmdImp/undeployImp.go
+++ b/cmdImp/undeployImp.go
@@ -15,19 +15,19 @@ func Undeploy(params DeployParams) error {
 	whisk.SetVerbose(params.Verbose)
 
 	if params.ManifestPath == "" {
-		if ok, _ := regexp.Match(ManifestFileNameYml, []byte(params.ManifestPath)); ok {
-			params.ManifestPath = path.Join(params.ProjectPath, ManifestFileNameYml)
+		if ok, _ := regexp.Match(deployers.ManifestFileNameYml, []byte(params.ManifestPath)); ok {
+			params.ManifestPath = path.Join(params.ProjectPath, deployers.ManifestFileNameYml)
 		} else {
-			params.ManifestPath = path.Join(params.ProjectPath, ManifestFileNameYaml)
+			params.ManifestPath = path.Join(params.ProjectPath, deployers.ManifestFileNameYaml)
 		}
 
 	}
 
 	if params.DeploymentPath == "" {
-		if ok, _ := regexp.Match(DeploymentFileNameYml, []byte(params.ManifestPath)); ok {
-			params.DeploymentPath = path.Join(params.ProjectPath, DeploymentFileNameYml)
+		if ok, _ := regexp.Match(deployers.DeploymentFileNameYml, []byte(params.ManifestPath)); ok {
+			params.DeploymentPath = path.Join(params.ProjectPath, deployers.DeploymentFileNameYml)
 		} else {
-			params.DeploymentPath = path.Join(params.ProjectPath, DeploymentFileNameYaml)
+			params.DeploymentPath = path.Join(params.ProjectPath, deployers.DeploymentFileNameYaml)
 		}
 
 	}

--- a/deployers/servicedeployer.go
+++ b/deployers/servicedeployer.go
@@ -20,14 +20,15 @@ package deployers
 import (
 	"bufio"
 	"fmt"
+	"log"
 	"os"
+	"path"
 	"strings"
 	"sync"
 
 	"github.com/openwhisk/openwhisk-client-go/whisk"
 	"github.com/openwhisk/openwhisk-wskdeploy/parsers"
 	"github.com/openwhisk/openwhisk-wskdeploy/utils"
-	"log"
 )
 
 type DeploymentApplication struct {
@@ -47,13 +48,15 @@ func NewDeploymentApplication() *DeploymentApplication {
 }
 
 type DeploymentPackage struct {
-	Package   *whisk.Package
-	Actions   map[string]utils.ActionRecord
-	Sequences map[string]utils.ActionRecord
+	Package      *whisk.Package
+	Dependencies map[string]utils.DependencyRecord
+	Actions      map[string]utils.ActionRecord
+	Sequences    map[string]utils.ActionRecord
 }
 
 func NewDeploymentPackage() *DeploymentPackage {
 	var dep DeploymentPackage
+	dep.Dependencies = make(map[string]utils.DependencyRecord)
 	dep.Actions = make(map[string]utils.ActionRecord)
 	dep.Sequences = make(map[string]utils.ActionRecord)
 	return &dep
@@ -78,6 +81,7 @@ type ServiceDeployer struct {
 	DeployActionInPackage bool
 	InteractiveChoice     bool
 	ClientConfig          *whisk.Config
+	DependencyMaster      map[string]utils.DependencyRecord
 }
 
 // NewServiceDeployer is a Factory to create a new ServiceDeployer
@@ -86,6 +90,7 @@ func NewServiceDeployer() *ServiceDeployer {
 	dep.Deployment = NewDeploymentApplication()
 	dep.IsInteractive = true
 	dep.DeployActionInPackage = true
+	dep.DependencyMaster = make(map[string]utils.DependencyRecord)
 
 	return &dep
 }
@@ -105,6 +110,7 @@ func (deployer *ServiceDeployer) Check() {
 func (deployer *ServiceDeployer) ConstructDeploymentPlan() error {
 
 	var manifestReader = NewManfiestReader(deployer)
+	manifestReader.IsUndeploy = false
 	manifest, manifestParser, err := manifestReader.ParseManifest()
 	utils.Check(err)
 
@@ -138,6 +144,7 @@ func (deployer *ServiceDeployer) ConstructDeploymentPlan() error {
 func (deployer *ServiceDeployer) ConstructUnDeploymentPlan() (*DeploymentApplication, error) {
 
 	var manifestReader = NewManfiestReader(deployer)
+	manifestReader.IsUndeploy = true
 	manifest, manifestParser, err := manifestReader.ParseManifest()
 	utils.Check(err)
 
@@ -221,6 +228,10 @@ func (deployer *ServiceDeployer) deployAssets() error {
 		return err
 	}
 
+	if err := deployer.DeployDependencies(); err != nil {
+		return err
+	}
+
 	if err := deployer.DeployActions(); err != nil {
 		return err
 	}
@@ -240,6 +251,47 @@ func (deployer *ServiceDeployer) deployAssets() error {
 	if len(deployer.Deployment.Apis) != 0 {
 		if err := deployer.DeployApis(); err != nil {
 			return err
+		}
+	}
+
+	return nil
+}
+
+func (deployer *ServiceDeployer) DeployDependencies() error {
+	for _, pack := range deployer.Deployment.Packages {
+		for depName, depRecord := range pack.Dependencies {
+			fmt.Println("Deploying dependency " + depName + " ... ")
+
+			if depRecord.IsBinding {
+				bindingPackage := new(whisk.BindingPackage)
+				bindingPackage.Namespace = pack.Package.Namespace
+				bindingPackage.Name = depName
+				pub := false
+				bindingPackage.Publish = &pub
+
+				qName, err := utils.ParseQualifiedName(depRecord.Location, pack.Package.Namespace)
+				utils.Check(err)
+				bindingPackage.Binding = whisk.Binding{qName.Namespace, qName.EntityName}
+
+				bindingPackage.Parameters = depRecord.Parameters
+				bindingPackage.Annotations = depRecord.Annotations
+
+				deployer.createBinding(bindingPackage)
+
+			} else {
+				depServiceDeployer, err := deployer.getDependentDeployer(depName, depRecord)
+				utils.Check(err)
+
+				err = depServiceDeployer.ConstructDeploymentPlan()
+				utils.Check(err)
+
+				if err := depServiceDeployer.deployAssets(); err != nil {
+					log.Println("\nDeployment of dependency " + depName + " did not complete sucessfully. Run `wskdeploy undeploy` to remove partially deployed assets")
+					return err
+				} else {
+					fmt.Println("Done!")
+				}
+			}
 		}
 	}
 
@@ -309,6 +361,16 @@ func (deployer *ServiceDeployer) DeployApis() error {
 	return nil
 }
 
+func (deployer *ServiceDeployer) createBinding(packa *whisk.BindingPackage) {
+	log.Print("Deploying package binding" + packa.Name + " ... ")
+	_, _, err := deployer.Client.Packages.Insert(packa, true)
+	if err != nil {
+		wskErr := err.(*whisk.WskError)
+		log.Printf("Got error creating package binding with error message: %v and error code: %v.\n", wskErr.Error(), wskErr.ExitCode)
+	}
+	log.Println("Done!")
+}
+
 func (deployer *ServiceDeployer) createPackage(packa *whisk.Package) {
 	log.Print("Deploying package " + packa.Name + " ... ")
 	_, _, err := deployer.Client.Packages.Insert(packa, true)
@@ -335,12 +397,7 @@ func (deployer *ServiceDeployer) createFeedAction(trigger *whisk.Trigger, feedNa
 
 	// check for strings that are JSON
 	for _, keyVal := range trigger.Parameters {
-		if b, isJson := utils.IsJSON(keyVal.Value.(string)); isJson {
-			fmt.Println(keyVal.Key + " is JSON " + keyVal.Value.(string))
-			params[keyVal.Key] = b
-		} else {
-			params[keyVal.Key] = keyVal.Value
-		}
+		params[keyVal.Key] = keyVal.Value
 	}
 
 	params["authKey"] = deployer.ClientConfig.AuthToken
@@ -498,8 +555,41 @@ func (deployer *ServiceDeployer) unDeployAssets(verifiedPlan *DeploymentApplicat
 		return err
 	}
 
+	if err := deployer.UnDeployDependencies(); err != nil {
+		return err
+	}
+
 	return nil
 
+}
+
+func (deployer *ServiceDeployer) UnDeployDependencies() error {
+	for _, pack := range deployer.Deployment.Packages {
+		for depName, depRecord := range pack.Dependencies {
+			fmt.Println("Undeploying dependency " + depName + " ... ")
+
+			if depRecord.IsBinding {
+				_, err := deployer.Client.Packages.Delete(depName)
+				utils.Check(err)
+			} else {
+
+				depServiceDeployer, err := deployer.getDependentDeployer(depName, depRecord)
+				utils.Check(err)
+
+				plan, err := depServiceDeployer.ConstructUnDeploymentPlan()
+				utils.Check(err)
+
+				if err := depServiceDeployer.unDeployAssets(plan); err != nil {
+					log.Println("\nUndeployment of dependency " + depName + " did not complete sucessfully. Run `wskdeploy undeploy` to remove partially deployed assets")
+					return err
+				} else {
+					fmt.Println("Done!")
+				}
+			}
+		}
+	}
+
+	return nil
 }
 
 func (deployer *ServiceDeployer) UnDeployPackages(deployment *DeploymentApplication) error {
@@ -680,6 +770,16 @@ func (deployer *ServiceDeployer) printDeploymentAssets(assets *DeploymentApplica
 			fmt.Printf("        - %s : %v\n", p.Key, utils.PrettyJSON(p.Value))
 		}
 
+		for key, dep := range pack.Dependencies {
+			fmt.Println("  * dependency: " + key)
+			fmt.Println("    location: " + dep.Location)
+			if !dep.IsBinding {
+				fmt.Println("    local path: " + dep.ProjectPath)
+			}
+		}
+
+		fmt.Println("")
+
 		for _, action := range pack.Actions {
 			fmt.Println("  * action: " + action.Action.Name)
 			fmt.Println("    bindings: ")
@@ -729,4 +829,25 @@ func (deployer *ServiceDeployer) printDeploymentAssets(assets *DeploymentApplica
 
 	fmt.Println("")
 
+}
+
+func (deployer *ServiceDeployer) getDependentDeployer(depName string, depRecord utils.DependencyRecord) (*ServiceDeployer, error) {
+	depServiceDeployer := NewServiceDeployer()
+	projectPath := path.Join(depRecord.ProjectPath, depName+"-"+depRecord.Version)
+	manifestPath := path.Join(projectPath, ManifestFileNameYml)
+	deploymentPath := path.Join(projectPath, DeploymentFileNameYaml)
+	depServiceDeployer.ProjectPath = projectPath
+	depServiceDeployer.ManifestPath = manifestPath
+	depServiceDeployer.DeploymentPath = deploymentPath
+	depServiceDeployer.IsInteractive = true
+
+	depServiceDeployer.Client = deployer.Client
+	depServiceDeployer.ClientConfig = deployer.ClientConfig
+
+	depServiceDeployer.DependencyMaster = deployer.DependencyMaster
+
+	// share the master dependency list
+	depServiceDeployer.DependencyMaster = deployer.DependencyMaster
+
+	return depServiceDeployer, nil
 }

--- a/deployers/shared.go
+++ b/deployers/shared.go
@@ -16,17 +16,10 @@
  */
 
 // shared.go
-package cmdImp
+package deployers
 
-var CfgFile string
-var CliVersion string
-var CliBuild string
-
-// used to configure service deployer for various commands
-// TODO: should move this into utils.Flags
-var Verbose bool
-var ProjectPath string
-var DeploymentPath string
-var ManifestPath string
-var UseDefaults bool
-var UseInteractive bool
+// name of manifest and deployment files
+const ManifestFileNameYaml = "manifest.yaml"
+const ManifestFileNameYml = "manifest.yml"
+const DeploymentFileNameYaml = "deployment.yaml"
+const DeploymentFileNameYml = "deployment.yml"

--- a/parsers/yamlparser.go
+++ b/parsers/yamlparser.go
@@ -72,9 +72,10 @@ type Sequence struct {
 }
 
 type Dependency struct {
-	Name    string
-	Url     string
-	Version string
+	Version     string                 `yaml: "version, omitempty"`
+	Location    string                 `yaml: "location, omitempty"`
+	Inputs      map[string]Parameter   `yaml:"inputs"`
+	Annotations map[string]interface{} `yaml:"annotations"`
 }
 
 type Parameter struct {
@@ -191,6 +192,7 @@ func (rule *Rule) ComposeWskRule() *whisk.Rule {
 	pub := false
 	wskrule.Publish = &pub
 	wskrule.Trigger = rule.Trigger
+
 	wskrule.Action = rule.Action
 	return wskrule
 }

--- a/tests/src/integration/dependency/dependency_test.go
+++ b/tests/src/integration/dependency/dependency_test.go
@@ -1,0 +1,28 @@
+// +build integration
+
+package tests
+
+import (
+	"github.com/openwhisk/openwhisk-wskdeploy/tests/src/integration/common"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+
+var wskprops = common.GetWskprops()
+
+// TODO: write the integration against openwhisk
+func TestDependency(t *testing.T) {
+	os.Setenv("__OW_API_HOST", wskprops.APIHost)
+	wskdeploy := common.NewWskdeploy()
+	_, err := wskdeploy.Deploy(manifestPath, deploymentPath)
+	assert.Equal(t, nil, err, "Failed to deploy based on the manifest and deployment files.")
+	_, err = wskdeploy.Undeploy(manifestPath, deploymentPath)
+	assert.Equal(t, nil, err, "Failed to undeploy based on the manifest and deployment files.")
+}
+
+var (
+	manifestPath   = os.Getenv("GOPATH") + "/src/github.com/openwhisk/openwhisk-wskdeploy/tests/src/integration/dependency/manifest.yaml"
+	deploymentPath = ""
+)

--- a/tests/src/integration/dependency/manifest.yaml
+++ b/tests/src/integration/dependency/manifest.yaml
@@ -1,0 +1,26 @@
+package:
+  name: opentest
+  namespace: guest
+  credential: 23bc46b1-71f6-4ed5-8c54-816aa4f8c502:123zO3xZCLrMN6v2BKK1dXYFpXlPkccOFqm12CdAsMgRU4VrNZ9lyGVCGuMDGIwP
+  baseUrl: https://172.17.0.1/api
+  dependencies:
+    hellowhisk:
+      location: github.com/paulcastro/hellowhisk
+    myCloudant:
+      location: /whisk.system/cloudant
+      inputs:
+        dbname: myGreatDB
+      annotations:
+        myAnnotation: Here it is
+  sequences:
+    mySequence:
+      actions: hellowhisk/greeting, hellowhisk/httpGet
+  triggers:
+    myTrigger:
+  rules:
+    myRule:
+      trigger: myTrigger
+      action: hellowhisk/httpGet
+    myCloudantRule:
+      trigger: myTrigger
+      action: myCloudant/create-database

--- a/tests/usecases/dependency/manifest.yaml
+++ b/tests/usecases/dependency/manifest.yaml
@@ -1,0 +1,23 @@
+package:
+  name: opentest
+  dependencies:
+    hellowhisk:
+      location: github.com/paulcastro/hellowhisk
+    myCloudant:
+      location: /whisk.system/cloudant
+      inputs:
+        dbname: myGreatDB
+      annotations:
+        myAnnotation: Here it is
+  sequences:
+    mySequence:
+      actions: hellowhisk/greeting, hellowhisk/httpGet
+  triggers:
+    myTrigger:
+  rules:
+    myRule:
+      trigger: myTrigger
+      action: hellowhisk/httpGet
+    myCloudantRule:
+      trigger: myTrigger
+      action: myCloudant/create-database

--- a/tests/usecases/openstack/manifest.yaml
+++ b/tests/usecases/openstack/manifest.yaml
@@ -2,10 +2,6 @@ package:
   name: JiraBackupSolution
   version: 0.0.1
   license: Apache-2.0
-  dependencies:
-    SwiftyJson:
-      url: https://swiftyjson.com
-      version: 0.4.0
   actions:
     getApiToken:
       location: actions/getApiToken.js

--- a/utils/dependencies.go
+++ b/utils/dependencies.go
@@ -1,0 +1,34 @@
+// dependencies.go
+package utils
+
+import (
+	"strings"
+
+	"github.com/openwhisk/openwhisk-client-go/whisk"
+)
+
+type DependencyRecord struct {
+	ProjectPath string
+	Packagename string
+	Location    string
+	Version     string
+	Parameters  whisk.KeyValueArr
+	Annotations whisk.KeyValueArr
+	IsBinding   bool
+}
+
+func LocationIsBinding(location string) bool {
+	if strings.HasPrefix(location, "/whisk.system") || strings.HasPrefix(location, "whisk.system") {
+		return true
+	}
+
+	return false
+}
+
+func LocationIsGithub(location string) bool {
+	if strings.HasPrefix(location, "github.com") || strings.HasPrefix(location, "https://github.com") || strings.HasPrefix(location, "http://github.com") {
+		return true
+	}
+
+	return false
+}

--- a/utils/gitreader.go
+++ b/utils/gitreader.go
@@ -1,0 +1,87 @@
+// gitreader.go
+package utils
+
+import (
+	"archive/zip"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+type GitReader struct {
+	Name        string
+	Url         string
+	Version     string
+	ProjectPath string
+}
+
+func NewGitReader(projectName string, record DependencyRecord) *GitReader {
+	var gitReader GitReader
+
+	gitReader.Name = projectName
+	gitReader.Url = record.Location
+	gitReader.Version = record.Version
+
+	gitReader.ProjectPath = record.ProjectPath
+
+	return &gitReader
+
+}
+
+func (reader *GitReader) CloneDependency() error {
+	zipFileName := reader.Name + "." + reader.Version + ".zip"
+	zipFilePath := reader.Url + "/zipball" + "/" + reader.Version
+
+	os.MkdirAll(reader.ProjectPath, os.ModePerm)
+	output, err := os.Create(path.Join(reader.ProjectPath, zipFileName))
+	Check(err)
+	defer output.Close()
+
+	response, err := http.Get(zipFilePath)
+	Check(err)
+	defer response.Body.Close()
+
+	_, err = io.Copy(output, response.Body)
+	Check(err)
+
+	zipReader, err := zip.OpenReader(path.Join(reader.ProjectPath, zipFileName))
+	Check(err)
+
+	u, err := url.Parse(reader.Url)
+	team, project := path.Split(u.Path)
+
+	team = strings.TrimPrefix(team, "/")
+	team = strings.TrimSuffix(team, "/")
+
+	for _, file := range zipReader.File {
+		path := filepath.Join(reader.ProjectPath, file.Name)
+
+		if file.FileInfo().IsDir() {
+			os.MkdirAll(path, file.Mode())
+			continue
+		}
+
+		fileReader, err := file.Open()
+		Check(err)
+		defer fileReader.Close()
+
+		targetFile, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, file.Mode())
+		Check(err)
+		defer targetFile.Close()
+
+		if _, err := io.Copy(targetFile, fileReader); err != nil {
+			return err
+		}
+	}
+
+	rootDir := filepath.Join(reader.ProjectPath, zipReader.File[0].Name)
+	depPath := filepath.Join(reader.ProjectPath, project+"-"+reader.Version)
+	os.Rename(rootDir, depPath)
+	os.Remove(filepath.Join(reader.ProjectPath, zipFileName))
+
+	return nil
+}

--- a/utils/misc.go
+++ b/utils/misc.go
@@ -24,9 +24,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/hokaccha/go-prettyjson"
-	"github.com/openwhisk/openwhisk-client-go/whisk"
-	"github.com/openwhisk/openwhisk-wskdeploy/wski18n"
 	"io"
 	"net/url"
 	"os"
@@ -34,6 +31,10 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+
+	"github.com/hokaccha/go-prettyjson"
+	"github.com/openwhisk/openwhisk-client-go/whisk"
+	"github.com/openwhisk/openwhisk-wskdeploy/wski18n"
 )
 
 // ActionRecord is a container to keep track of


### PR DESCRIPTION
This is a first cut at adding dependencies to a manifest.yml file. This adds a dependencies key where the dependency is a GitHub repo.

```
package:
  name: opentest
  dependencies:
      hellowhisk:
          location: github.com/paulcastro/hellowhisk
          version: 1.0.1
      myCloudant:
           location: /whisk.system/cloudant
           inputs:
                  dbname: MyGreatDB
  sequences:
    mySequence:
      actions: hellowhisk/greeting, hellowhisk/httpGet
  triggers:
    myTrigger:
  rules:
    myRule:
      trigger: myTrigger
```

This manifest references a GitHub project aliased as "hellowhisk", version 1.0.1 at the given URL. If version is not specified, it will pull from master.

Dependencies specify a location, and the string prefix is used to determine the type of dependency. `/whisk.system`is a binding, and `github.com` specifies a GitHub dependency and is treated as an independent deployment. For example, the root package opentest refers to entities in the hellowhisk package using the package name format. The following happens on deploy

wskdeploy downloads and unpacks a zip file of the gihub repo in $ProjectPath/Packages/<dependencyname>
Deploys dependencies first
Deploys root package
This PR does not include dependency graph management so use at your own risk.

There is a use case in tests/usescases/deptest that illustrates a project that has no local source code, just a manifest that combines the entities in a dependency.

This super #236, #239.  Includes test fix from @houshengbo 